### PR TITLE
Security: Do not allow iframe to prevent Clickjacking attacks.

### DIFF
--- a/src/inc/config.php
+++ b/src/inc/config.php
@@ -1,6 +1,9 @@
 <?php
 session_start();
 
+// deny loading in <iframe>
+header( 'X-Frame-Options: DENY' );
+
 // prepare database configuration
 $DB = [
     'host' => 'localhost',


### PR DESCRIPTION
This prevents loading application in `<iframe>` tag.