### PR TITLE
Security: Set HttpOnly flag to session cookie.

### DIFF
--- a/src/inc/config.php
+++ b/src/inc/config.php
@@ -4,6 +4,9 @@ session_start();
 // deny loading in <iframe>
 header( 'X-Frame-Options: DENY' );
 
+// set HttpOnly flag to session cookie
+ini_set( 'session.cookie_httponly', 1 );
+
 // prepare database configuration
 $DB = [
     'host' => 'localhost',


### PR DESCRIPTION
This prevents reading `cookies` from javascript.